### PR TITLE
comment out global grunt in aliases.js

### DIFF
--- a/app/templates/grunt/aliases.js
+++ b/app/templates/grunt/aliases.js
@@ -1,4 +1,4 @@
-/*global grunt */
+///*global grunt */
 'use strict';
 
 module.exports = {


### PR DESCRIPTION
to avoid jshint error:

```
grunt test                                                                                                                              (05-02 14:37)
Running "newer:jshint" (newer) task
Running "newer:jshint:all" (newer) task
Running "jshint:all" (jshint) task
   grunt/aliases.js
      1 |/*global grunt */
                          ^ 'grunt' is defined but never used.
>> 1 error in 33 files
Warning: Task "jshint:all" failed. Use --force to continue.
Aborted due to warnings.
```
